### PR TITLE
fetch homepage menu items from backend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3361,6 +3361,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.0.tgz",
       "integrity": "sha512-1uIESzroqpaTzt9uX48HO+6gfnKu3RwvWdCcWSrX4csMInJfCo1yvKPNXCwXFRpJqRW25tiASb6No0YH57PXqg=="
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -5710,6 +5718,18 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "easy-peasy": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/easy-peasy/-/easy-peasy-5.0.3.tgz",
+      "integrity": "sha512-FRO1ClPWIhgfui7bSEOFqA/b1GuSlf98+5DuW1r1W1DC85nrJcke3rYemyKj/1B2kSzH90Ze6FM5uakUgqkzcQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.8",
+        "immer": "^8.0.1",
+        "redux": "^4.0.5",
+        "redux-thunk": "^2.3.0",
+        "ts-toolbelt": "^9.3.12"
       }
     },
     "ecc-jsbn": {
@@ -12952,6 +12972,19 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "redux": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
+      "integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -15237,6 +15270,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
+    },
+    "ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
     },
     "tsconfig-paths": {
       "version": "3.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,5 +71,5 @@
     "webpack": "^4.44.2",
     "webpack-cli": "^4.6.0"
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "https://locastic-backend.herokuapp.com:21165"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,5 +71,5 @@
     "webpack": "^4.44.2",
     "webpack-cli": "^4.6.0"
   },
-  "proxy": "https://locastic-backend.herokuapp.com:21165"
+  "proxy": "https://locastic-backend.herokuapp.com"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",
     "@types/jest": "^26.0.22",
+    "axios": "^0.21.1",
     "cross-spawn": "^7.0.3",
+    "easy-peasy": "^5.0.3",
     "fontsource-roboto": "^4.0.0",
     "formik": "^2.2.6",
     "react": "^17.0.2",
@@ -68,5 +70,6 @@
     "typescript": "^4.2.4",
     "webpack": "^4.44.2",
     "webpack-cli": "^4.6.0"
-  }
+  },
+  "proxy": "http://localhost:8080"
 }

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -6,7 +6,6 @@ import store from './store/store'
 
 test('renders landing page', () => {
   const testStore = store
-  // utilise initialState to preload our state
   const app = (
     <StoreProvider store={testStore}>
       <App />

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { StoreProvider } from 'easy-peasy';
+import store from './store/store'
 
 test('renders landing page', () => {
-  render(<App />);
+  const testStore = store
+  // utilise initialState to preload our state
+  const app = (
+    <StoreProvider store={testStore}>
+      <App />
+    </StoreProvider>
+  );
+  render(app)
   const linkElement = screen.getByText(/Welcome/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,26 +9,13 @@ import cookieGiftBasket from './images/cookieGiftBasket.jpg';
 import 'fontsource-roboto';
 import Cart from './Cart';
 import { CartPageView, Checkout, ItemPage, NavBar } from './views'
+import { menuItem, itemCategories } from './model'
 
 import {
   BrowserRouter as Router,
   Route,
   Switch
 } from 'react-router-dom';
-
-export enum itemCategories {
-  BakeryItem,
-  GiftBasket,
-}
-export interface menuItem {
-  id: number,
-  name: string,
-  price: number,
-  image: string,
-  seller: string,
-  category: itemCategories,
-  description?: string,
-}
 
 const defaultDescription = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tristique, mi nec interdum blandit, justo lacus suscipit arcu, at porta magna metus sed lacus. Nullam in nunc vitae turpis ullamcorper tempor at eget leo. Curabitur condimentum ipsum id velit porta consectetur. Aliquam eget velit non ipsum dapibus suscipit id sed nisi. Ut viverra velit eu mi placerat, in consequat leo blandit. Suspendisse tristique quam id odio mattis elementum. Cras elementum tellus at volutpat pulvinar. Fusce vehicula sollicitudin tempus. Suspendisse potenti. Quisque rhoncus iaculis neque eget vestibulum. Quisque tempus pretium ligula non euismod."
 
@@ -76,7 +63,6 @@ export default function App() {
   const addItemToCart = (menuItem: menuItem) => {
     const newCart = new Cart().setTo(customerCart).incrementQty(menuItem);
     setCustomerCart(newCart);
-    console.log(customerCart);
   }
   const removeItemFromCart = (menuItem: menuItem) => {
     const newCart = new Cart().setTo(customerCart).decrementQty(menuItem);

--- a/frontend/src/Cart.ts
+++ b/frontend/src/Cart.ts
@@ -1,4 +1,4 @@
-import { menuItem } from "./App";
+import { menuItem } from "./model";
 import { CartItem } from "./CartItem";
 
 interface cartItemDict {

--- a/frontend/src/CartItem.ts
+++ b/frontend/src/CartItem.ts
@@ -1,4 +1,4 @@
-import { menuItem } from "./App";
+import { menuItem } from "./model";
 
 export class CartItem {
   quantity: number;

--- a/frontend/src/components/CartToggle.tsx
+++ b/frontend/src/components/CartToggle.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { IconButton, Typography } from '@material-ui/core';
 
 import { LoctasticContext } from '../contexts/LoctasticContext';
-import { menuItem } from '../App';
+import { menuItem } from '../model';
 
 
 const useStyles = makeStyles((theme) => ({

--- a/frontend/src/contexts/LoctasticContext.ts
+++ b/frontend/src/contexts/LoctasticContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import { menuItem } from "../App";
+import { menuItem } from "../model";
 import Cart from "../Cart";
 
 const defaultMenuItems: menuItem[] = [];

--- a/frontend/src/hooks.tsx
+++ b/frontend/src/hooks.tsx
@@ -1,0 +1,8 @@
+import { createTypedHooks } from 'easy-peasy';
+import { StoreModel } from './model';
+
+const typedHooks = createTypedHooks<StoreModel>();
+
+export const useStoreActions = typedHooks.useStoreActions;
+export const useStoreDispatch = typedHooks.useStoreDispatch;
+export const useStoreState = typedHooks.useStoreState;

--- a/frontend/src/hooks.tsx
+++ b/frontend/src/hooks.tsx
@@ -1,7 +1,7 @@
 import { createTypedHooks } from 'easy-peasy';
-import { StoreModel } from './model';
+import { storeModel } from './model';
 
-const typedHooks = createTypedHooks<StoreModel>();
+const typedHooks = createTypedHooks<storeModel>();
 
 export const useStoreActions = typedHooks.useStoreActions;
 export const useStoreDispatch = typedHooks.useStoreDispatch;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,11 +3,13 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { StoreProvider } from 'easy-peasy';
+import store from './store/store';
 
 ReactDOM.render(
-  <React.StrictMode>
+  <StoreProvider store={store}>
     <App />
-  </React.StrictMode>,
+  </StoreProvider>,
   document.getElementById('root')
 );
 

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -1,0 +1,23 @@
+import { Action, Thunk } from 'easy-peasy';
+
+export enum itemCategories {
+    BakeryItem,
+    GiftBasket,
+}
+
+export interface menuItem {
+    id: number,
+    name: string,
+    price: number,
+    image: string,
+    seller: string,
+    category: itemCategories,
+    description?: string,
+}
+
+export interface StoreModel {
+    menuItems: menuItem[];
+    setMenuItems: Action<StoreModel, menuItem[]>;
+    fetchMenuItems: Thunk<StoreModel>;
+}
+

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -15,9 +15,9 @@ export interface menuItem {
     description?: string,
 }
 
-export interface StoreModel {
+export interface storeModel {
     menuItems: menuItem[];
-    setMenuItems: Action<StoreModel, menuItem[]>;
-    fetchMenuItems: Thunk<StoreModel>;
+    setMenuItems: Action<storeModel, menuItem[]>;
+    fetchMenuItems: Thunk<storeModel>;
 }
 

--- a/frontend/src/store/store.tsx
+++ b/frontend/src/store/store.tsx
@@ -1,8 +1,8 @@
 import { createStore, action, thunk, persist } from 'easy-peasy'
-import { StoreModel, menuItem } from "../model"
+import { storeModel, menuItem } from "../model"
 import axios from 'axios'
 
-const store = createStore<StoreModel>(persist({
+const store = createStore<storeModel>(persist({
     menuItems: [],
     setMenuItems: action((state, payload) => {
         state.menuItems = payload

--- a/frontend/src/store/store.tsx
+++ b/frontend/src/store/store.tsx
@@ -1,0 +1,22 @@
+import { createStore, action, thunk, persist } from 'easy-peasy'
+import { StoreModel, menuItem } from "../model"
+import axios from 'axios'
+
+const store = createStore<StoreModel>(persist({
+    menuItems: [],
+    setMenuItems: action((state, payload) => {
+        state.menuItems = payload
+    }),
+    fetchMenuItems: thunk(async actions => {
+        let menuItems: menuItem[] = []
+        try {
+            const { data } = await axios.get('/homepage_items')
+            menuItems = data.menu_items
+            actions.setMenuItems(menuItems);
+        } catch (error) {
+            console.log(error)
+        }
+    }), 
+}))
+
+export default store;

--- a/frontend/src/views/Home.tsx
+++ b/frontend/src/views/Home.tsx
@@ -1,10 +1,10 @@
 
-import React, { useContext } from 'react';
+import React, { useEffect } from 'react';
 import { Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import { LoctasticContext } from '../contexts/LoctasticContext';
 import MenuItem from './MenuItem';
-import { itemCategories, menuItem } from '../App';
+import { itemCategories, menuItem } from '../model';
+import { useStoreState, useStoreActions } from '../hooks'
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -27,7 +27,13 @@ const useStyles = makeStyles(theme => ({
 
 export default function Home() {
     const classes = useStyles();
-    const { menuItems } = useContext(LoctasticContext);
+    const menuItems = useStoreState(state => state.menuItems)
+    const fetchMenuItems = useStoreActions(actions => actions.fetchMenuItems)
+
+    useEffect(() => {
+        fetchMenuItems()
+    }, [])
+
     return (
         <div className={classes.root}>
             <div className={classes.root}>
@@ -35,11 +41,11 @@ export default function Home() {
             </div>
             <h3>Bakery items</h3>
             <Grid container spacing={1}>
-                {menuItems.filter(menuItem => menuItem.category === itemCategories.BakeryItem).map((menuItem: menuItem) => <MenuItem key={menuItem.id} menuItem={menuItem} />)}
+                { menuItems ? menuItems.filter(menuItem => menuItem.category === itemCategories.BakeryItem).map((menuItem: menuItem) => <MenuItem key={menuItem.id} menuItem={menuItem} />) : null }
             </Grid>
             <h3>Gift Baskets</h3>
             <Grid container spacing={1}>
-            {menuItems.filter(menuItem => menuItem.category === itemCategories.GiftBasket).map((menuItem: menuItem) => <MenuItem key={menuItem.id} menuItem={menuItem} /> )}
+                { menuItems ? menuItems.filter(menuItem => menuItem.category === itemCategories.GiftBasket).map((menuItem: menuItem) => <MenuItem key={menuItem.id} menuItem={menuItem} /> ) : null }
             </Grid>
         </div>
     )

--- a/frontend/src/views/Home.tsx
+++ b/frontend/src/views/Home.tsx
@@ -32,7 +32,7 @@ export default function Home() {
 
     useEffect(() => {
         fetchMenuItems()
-    }, [])
+    }, [fetchMenuItems])
 
     return (
         <div className={classes.root}>

--- a/frontend/src/views/ItemPage.tsx
+++ b/frontend/src/views/ItemPage.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { LoctasticContext } from '../contexts/LoctasticContext';
 import { useParams } from "react-router-dom";
 import { Text, Row, Col, Page, Description, Tag, Image, Button } from '@geist-ui/react'
-import { itemCategories } from '../App';
+import { itemCategories } from '../model';
 import { CartToggle } from '../components'
 
 const ItemPage = () => {

--- a/frontend/src/views/MenuItem.tsx
+++ b/frontend/src/views/MenuItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Card, CardContent, CardMedia, Grid, Typography } from '@material-ui/core';
-import { menuItem } from '../App';
+import { menuItem } from '../model';
 import { Link as RouterLink } from 'react-router-dom';
 import Link from '@material-ui/core/Link';
 import { CartToggle } from '../components'

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
Used easy-peasy to create a global store of state for the app and app now calls backend for fetching menu items for homepage. 

# Note about failing tests
The jest and puppeteer tests will fail for now because we haven't linked a backend yet and the backend proxy in the code points to localhost which wouldn't be accessible on heroku deployment obviously. We need to deploy Heroku backend and then replace the localhost proxy address with Heroku deployment address.

<img width="1440" alt="Screen Shot 2021-05-08 at 11 16 08 PM" src="https://user-images.githubusercontent.com/17803773/117559542-3651bd00-b054-11eb-828c-a5e441e0ad32.png">
