### PR TITLE
Remove unneccessary mongo collection creation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -16,8 +16,8 @@ else:
 
 db = client.db
 
-db.myColl.drop()
-db.create_collection("myColl")  # Force create!
+# db.myColl.drop()
+# db.create_collection("myColl")  # Force create!
 
 
 # Order Schema for testing


### PR DESCRIPTION
I don't believe we are using `myColl`, removing it because it seems to be causing problems with the Heroku deployment.